### PR TITLE
Add asc-github script

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,14 @@ with the adapter.
 
 ascbot includes a `Dockerfile` for building a docker image able to run it.
 This image can then be used to run a docker container to complete the
-deployment. A local volume for the should be bound to the `/srv` path in order
-to ensure that the `hubot-brain.json` file has persistant storage. A slack
-"Bot User OAuth Access Token" needs to be passed as an environment variable in
-order to enable ascbot to connect to the slack workspace.
+deployment.
+
+* A local volume for the should be bound to the `/srv` path in order
+to ensure that the `hubot-brain.json` file has persistant storage.
+* A slack "Bot User OAuth Access Token" needs to be passed as an environment
+variable in order to enable ascbot to connect to the slack workspace.
+* A github token needs to be passed as an environment variable in order to
+enable ascbot to perform operations via the github api.
 
     % sudo docker build -t myuser/ascbot .
     % git push heroku master
@@ -108,5 +112,6 @@ order to enable ascbot to connect to the slack workspace.
           --name ascbot \
           -e HUBOT_BRAIN_DIR=/srv \
           -e HUBOT_SLACK_TOKEN=xoxb-<your-token> \
+          -e HUBOT_GITHUB_TOKEN=<your-token> \
           --volume "/local/docker/ascbot/config:/srv" \
           myuser/ascbot

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "hubot-shell": "^1.0.2",
     "hubot-shipit": "^0.2.1",
     "hubot-simpsons": "0.0.2",
+    "githubot": "^1.0.1",
     "lodash": "^4.17.11",
     "moment": "^2.23.0",
     "chrono-node": "^1.3.5",

--- a/scripts/asc-github.coffee
+++ b/scripts/asc-github.coffee
@@ -1,0 +1,54 @@
+# Description:
+#   Perform operations on github repos
+#
+# Dependencies:
+#   githubot
+#
+# Configuration:
+#   HUBOT_GITHUB_TOKEN
+#
+# Commands:
+#   hubot github update sha <repo> <branch>
+#   hubot github merge pr <repo> <number>
+#   hubot github list prs <repo>
+
+module.exports = (robot) ->
+
+  github = require('githubot')(robot)
+  owner = 'rcbops'
+
+  unless (url_api_base = process.env.HUBOT_GITHUB_API)?
+    url_api_base = 'https://api.github.com'
+
+  robot.respond /github update sha(s)? (.*)$/i, (msg) ->
+    [repo, branch] = msg.match[2].toLowerCase().split(' ')
+    repo = "rpc-openstack-system-tests" if repo in ["system-tests","sys-tests"]
+    # err if repo or branch not set
+    #
+    # github.branches "#{repo}", (branches) ->
+    #   err if branch not in branches
+    #
+    # create update-branch (api)
+    # clone repo (local)
+    # perform submodule update (local)
+    # commit update (local)
+    # push branch (local)
+    # open pr (api)
+    msg.send "You supplied repo: #{repo} and branch: #{branch}."
+    msg.send "This feature is under development. Please try again later."
+
+  robot.respond /github merge pr (.*)/i, (msg) ->
+    [repo, pr_number] = msg.match[1].toLowerCase().split(' ')
+    github.put "repos/#{owner}/#{repo}/pulls/#{pr_number}/merge", {}, (merge) ->
+      console.log merge.message
+
+  robot.respond /github list prs (.*)/i, (msg) ->
+    repo = msg.match[1].toLowerCase()
+    github.get "repos/#{owner}/#{repo}/pulls", {}, (pulls) ->
+      if pulls.length == 0
+        summary = "Achievment unlocked: no open pull requests!"
+      else
+        summary = "I found #{pulls.length} open pull requests for #{repo}:"
+        for pull in pulls
+          summary += "\n\t#{pull.title} - #{pull.user.login}: #{pull.html_url}"
+      msg.send summary


### PR DESCRIPTION
This commit adds the asc-github script. It currently can lookup pull
requests for a given repo and merge pull requests for a given repo and
pull number.

The pseudo-code for implementing the ability to update submodule shas is
also included in this commit.